### PR TITLE
Flag to negate incoming wrench

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ g_compensation
 
 * All calculations are based on [PyKDL](http://docs.ros.org/diamondback/api/kdl/html/python/) and [tf2](http://wiki.ros.org/tf2)
 
+* Some manipulators, like the KUKA iiwa or the Franka Emika Panda, publish the wrench data of their force-torque sensor in the opposite convention. I.e., they publish the wrench with which the environment acts on the manipulator. To convert such a signal into the more usual definition (the wrench with which the manipulator acts on the environment), the parameter **negate_wrench** can be set to `True` (default: `False`).
+
 * A rosservice */tare* can be called to tare in the current pose.
 
 ## Acknowledgements

--- a/include/g_compensation/g_compensator_class.h
+++ b/include/g_compensation/g_compensator_class.h
@@ -69,7 +69,7 @@ public:
             negate_wrench_flag_ = false; //default value
             ROS_WARN("Continuing with not negating the wrench received per default.");
         };
-        negate_wrench_ = int(negate_wrench_flag_) * -2 + 1;
+        negate_wrench_ = negate_wrench_flag_ ? -1 : 1;
     }
 
     bool getTransform(const std::string &target, const std::string &source, KDL::Frame &transform)

--- a/include/g_compensation/g_compensator_class.h
+++ b/include/g_compensation/g_compensator_class.h
@@ -63,13 +63,13 @@ public:
             ROS_WARN("Continuing with default buffer_size '50'.");
         };
 
-        bool negate_wrench_flag_;
-        if (!rosparam_shortcuts::get("g_compensator", n_static_params, "negate_wrench", negate_wrench_flag_))
+        bool negate_wrench_flag;
+        if (!rosparam_shortcuts::get("g_compensator", n_static_params, "negate_wrench", negate_wrench_flag))
         {
-            negate_wrench_flag_ = false; //default value
+            negate_wrench_flag = false; //default value
             ROS_WARN("Continuing with not negating the wrench received per default.");
         };
-        negate_wrench_ = negate_wrench_flag_ ? -1 : 1;
+        negate_wrench_ = negate_wrench_flag ? -1 : 1;
     }
 
     bool getTransform(const std::string &target, const std::string &source, KDL::Frame &transform)

--- a/include/g_compensation/g_compensator_class.h
+++ b/include/g_compensation/g_compensator_class.h
@@ -60,14 +60,14 @@ public:
         if (!rosparam_shortcuts::get("g_compensator", n_static_params, "buffer_size", buffer_size_))
         {
             buffer_size_ = 50; //default value
-            ROS_WARN("Continuing with default buffer_size '50'.");
+            ROS_INFO("Continuing with default buffer_size '50'.");
         };
 
         bool negate_wrench_flag;
         if (!rosparam_shortcuts::get("g_compensator", n_static_params, "negate_wrench", negate_wrench_flag))
         {
             negate_wrench_flag = false; //default value
-            ROS_WARN("Continuing with not negating the wrench received per default.");
+            ROS_INFO("Continuing with not negating the wrench received per default.");
         };
         negate_wrench_ = negate_wrench_flag ? -1 : 1;
     }

--- a/include/g_compensation/g_compensator_class.h
+++ b/include/g_compensation/g_compensator_class.h
@@ -62,6 +62,14 @@ public:
             buffer_size_ = 50; //default value
             ROS_WARN("Continuing with default buffer_size '50'.");
         };
+
+        bool negate_wrench_flag_;
+        if (!rosparam_shortcuts::get("g_compensator", n_static_params, "negate_wrench", negate_wrench_flag_))
+        {
+            negate_wrench_flag_ = false; //default value
+            ROS_WARN("Continuing with not negating the wrench received per default.");
+        };
+        negate_wrench_ = int(negate_wrench_flag_) * -2 + 1;
     }
 
     bool getTransform(const std::string &target, const std::string &source, KDL::Frame &transform)
@@ -109,7 +117,7 @@ public:
 
             //     # compensate
             tf::wrenchMsgToKDL(msg->wrench, message_wrench_);
-            compensated_ = message_wrench_ - gravity_at_sensor_;
+            compensated_ = negate_wrench_ * message_wrench_ - gravity_at_sensor_;
 
             if (last_updated_row_ >= buffer_size_)
             {
@@ -182,6 +190,7 @@ private:
     std::atomic_bool run_tare_ = {false};
     ros::ServiceServer srv_tare_;
 
+    int negate_wrench_;
     int buffer_size_;
     int last_updated_row_;
 

--- a/launch/g_compensator_example.launch
+++ b/launch/g_compensator_example.launch
@@ -8,6 +8,7 @@
                 com_frame: tool
                 gravity_frame: base_link
                 mass: 1.266
+                negate_wrench: false
             </rosparam>
         </node>
 

--- a/launch/g_compensator_example.launch
+++ b/launch/g_compensator_example.launch
@@ -18,6 +18,7 @@
                 com_frame: tool
                 gravity_frame: base_link
                 mass: 1.266
+                negate_wrench: false
             </rosparam>
             <remap from="wrench_compensated" to="wrench_compensated_cpp"/>
             <remap from="tare" to="tare_cpp" />

--- a/src/g_compensation/g_compensator.py
+++ b/src/g_compensation/g_compensator.py
@@ -55,6 +55,7 @@ if __name__ == '__main__':
     mass = rospy.get_param('~mass')
     gravity_frame = rospy.get_param('~gravity_frame', 'world')
     com_frame = rospy.get_param('~com_frame')  # com = center of mass
+    negate_wrench = -1 if rospy.get_param('~negate_wrench', False) else 1
 
     gravity = kdl.Wrench(kdl.Vector(0, 0, -9.81*mass), kdl.Vector(0, 0, 0))
     tare_offset = kdl.Wrench(kdl.Vector(0, 0, 0), kdl.Vector(0, 0, 0))
@@ -91,7 +92,7 @@ if __name__ == '__main__':
         gravity_at_sensor = tf_com * gravity_at_com
 
         # compensate
-        compensated = wrench_msg_to_kdl(msg) - gravity_at_sensor
+        compensated = negate_wrench * wrench_msg_to_kdl(msg) - gravity_at_sensor
         wrench_buffer.append(compensated)
 
         # Tare


### PR DESCRIPTION
Sometimes, the force-torque signal published on the wrench topic has the opposite sign than it "should." Unfortunately, multiplying a vector/matrix with a scalar -1 is not a transformation with a rotational equivalent; hence this feature.

The implementation should be non-breaking.

- [x] Implement the flag for the python node
- [x] Implement the flag for the C++ node
- [x] Test the feature